### PR TITLE
chore: LangChain4j 버전 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,54 +1,54 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'org.lucky0111'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-	// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
-	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
-	implementation 'dev.langchain4j:langchain4j-mcp:1.0.0-beta3'
-	implementation 'dev.langchain4j:langchain4j-google-ai-gemini-spring-boot-starter:1.0.0-beta3'
-	implementation 'dev.langchain4j:langchain4j-spring-boot-starter:1.0.0-beta3'
+    implementation 'dev.langchain4j:langchain4j-mcp:1.0.0-beta4'
+    implementation 'dev.langchain4j:langchain4j-google-ai-gemini-spring-boot-starter:1.0.0-beta4'
+    implementation 'dev.langchain4j:langchain4j-spring-boot-starter:1.0.0-beta4'
 
-	implementation(platform("software.amazon.awssdk:bom:2.31.38"))
-	implementation("software.amazon.awssdk:s3")
+    implementation(platform("software.amazon.awssdk:bom:2.31.38"))
+    implementation("software.amazon.awssdk:s3")
 
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/org/lucky0111/pettalk/config/mcp/McpAssistantConfig.java
+++ b/src/main/java/org/lucky0111/pettalk/config/mcp/McpAssistantConfig.java
@@ -7,8 +7,7 @@ import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import org.lucky0111.pettalk.assistants.McpTagAssistant;
 import org.lucky0111.pettalk.assistants.McpUserAssistant;
@@ -60,7 +59,7 @@ public class McpAssistantConfig {
     public McpTransport transport() {
         return new HttpMcpTransport.Builder()
                 .sseUrl(sseUrl)
-                .timeout(Duration.ofSeconds(604800)) // 7일
+                .timeout(Duration.ofSeconds(600))
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -86,20 +85,20 @@ public class McpAssistantConfig {
     }
 
     @Bean
-    public McpUserAssistant mcpUserAssistant(ChatLanguageModel chatLanguageModel,
+    public McpUserAssistant mcpUserAssistant(ChatModel chatLanguageModel,
                                              McpToolProvider toolProvider, ChatMemory chatMemory) {
         return AiServices.builder(McpUserAssistant.class)
-                .chatLanguageModel(chatLanguageModel)
+                .chatModel(chatLanguageModel)
                 .toolProvider(toolProvider)
                 .chatMemory(chatMemory)
                 .build();
     }
 
     @Bean
-    public McpTagAssistant mcpTagAssistant(ChatLanguageModel chatLanguageModel,
-                                            McpToolProvider toolProvider, ChatMemory chatMemory) {
+    public McpTagAssistant mcpTagAssistant(ChatModel chatLanguageModel,
+                                           McpToolProvider toolProvider, ChatMemory chatMemory) {
         return AiServices.builder(McpTagAssistant.class)
-                .chatLanguageModel(chatLanguageModel)
+                .chatModel(chatLanguageModel)
                 .toolProvider(toolProvider)
                 .chatMemory(chatMemory)
                 .build();

--- a/src/main/java/org/lucky0111/pettalk/service/auth/CustomOAuth2UserService.java
+++ b/src/main/java/org/lucky0111/pettalk/service/auth/CustomOAuth2UserService.java
@@ -56,7 +56,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         user.setNickname("임시사용자_" + UUID.randomUUID());
         user.setSocialId(socialId);
         user.setEmail(email);
-        user.setRole(UserRole.GUEST);
+        user.setRole(UserRole.USER);
         user.setProvider(oAuth2Provider.getRegistrationId());
         user.setProfileImageUrl(""); // TODO: 기본 프사 이미지 URL로 수정 필요
         user.setStatus(AccountStatus.ACTIVE.toString());


### PR DESCRIPTION
<!-- 👋 아래 양식에 맞게 PR 작성 -->

## 📌 PR 유형 (하나 이상 선택)
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🔍 변경사항 요약
<!-- 변경된 내용 한 줄 요약 -->

- langchain4j 버전 업데이트
  - 1.0.0-beta3 -> 1.0.0-beta4

---

## 🔗 관련 이슈
- Resolves: #ISSUE_NUMBER

---

## 📚 참고 사항
<!-- 참고 자료 링크 혹은 TODO, 개선 사항 작성 -->

### 📢 공지사항

다음 모듈들에 대해 **버전 1.0.0-rc1**(릴리즈 후보 1)이 출시되었음을 기쁘게 알려드립니다:

* `langchain4j-core`
* `langchain4j`
* `langchain4j-http-client`
* `langchain4j-http-client-jdk`
* `langchain4j-open-ai`

나머지 모듈들은 여전히 **1.0.0-beta4** 버전으로 릴리즈되었습니다. 현재 남은 업데이트를 마무리 중이며, **6월에 나머지 모듈들도 1.0.0-rc1로 출시**할 계획입니다.

1.0.0-rc1 버전을 사용해보시고, 피드백을 공유해 주세요. **최종 1.0.0 버전은 5월 중순에 출시**할 예정입니다.

만약 `langchain4j-bom`을 사용 중이라면 해당 버전은 여전히 1.0.0-beta4지만, 위에 언급된 모듈들의 최신 버전(1.0.0-rc1 포함)을 포함하고 있습니다.

---

### ⚠️ 주요 변경사항 (Breaking Changes)

이번 릴리즈에는 다음과 같은 주요 변경사항(호환성 깨짐)이 포함되어 있습니다. 세부사항은 관련 PR 링크에서 확인하세요:

* `ChatLanguageModel` → `ChatModel`
  `StreamingChatLanguageModel` → `StreamingChatModel`
  *(by @dliubarskyi, PR #2866)*

* `Tokenizer` → `TokenCountEstimator`
  *(by @dliubarskyi, PR #2874)*

* 이슈 #2794 수정 *(PR #2906)*

* 불필요한 `TextFile` 및 `TextFileContent` 제거 *(PR #2908)*

* `maxRetries` 관련 이슈 #2918 수정 *(PR #2919)*

* Kotlin 확장 기능을 별도 모듈로 이동 *(PR #2943)*

* 민감 정보 로그 제거 *(PR #2934)*

* `ChatMemoryAccess` 클래스 `dev.langchain4j.service.memory` 패키지로 이동 *(커밋 082a758)*

* API에서 반환하는 컬렉션(List, Set, Map 등)은 이제 **절대 null이 아님**. 대신 빈 컬렉션을 반환합니다.

* 일부 내부 유틸리티 클래스 이름 변경 및 위치 이동. 이들 클래스는 `@Internal`로 표시되었으며, **직접 사용하지 말아야 합니다.**

📌 **마이그레이션을 쉽게 하려면 아래 OpenRewrite 레시피를 사용하세요:**

```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:6.7.0:run \
  -Drewrite.recipeArtifactCoordinates=dev.langchain4j:langchain4j-openrewrite-recipes:1.0.0-rc1 \
  -Drewrite.activeRecipes=dev.langchain4j.UpgradeToRc1AndBeta4
```

🔺 반드시 버전을 1.0.0-rc1 및 1.0.0-beta4로 업데이트하기 **전에** 위 명령어를 실행하세요.

---

### 🔧 기타 변경사항

* MCP 툴 함수에 인자가 없을 때 발생하는 버그 수정 (#2776)
* `maven-deploy-plugin` 3.1.4로 업데이트 (#2850)
* \#2620 이후 수정 (#2851)
* VertexAI 스트리밍 채팅 모델에 커스텀 헤더 지원 추가 (#2835, #2838)
* `maven-failsafe-plugin` 3.5.3으로 업데이트 (#2860)
* MCP HTTP 자동 재연결 기능 추가 (#2862)
* MCP 트래픽 로그를 'MCP'라는 이름의 로거로 이동 (#2869)
* `AI Services`, `ChatResponseMetadata`, `TokenUsage` 개선 (#2883)
* 이슈 #2867 수정 (#2875)
* `quarkus-mcp-server` 테스트 업데이트 및 사소한 테스트 수정 (#2902)
* 보안 정책 문서 추가 (#2904)
* Helidon 통합 문서 추가 (#2859)
* `google-vertex-ai.md` 문서 업데이트 (#2493)
* OpenAI Java SDK 1.4.1로 업그레이드 (#2868)
* MCP 클라이언트 초기화 타임아웃 도입 (#2912)
* `kotlinx-coroutines` 버전을 1.8.1로 다운그레이드 (#2936)
* DashScope 문서 업데이트 (#2923, #2913)
* Google AI Gemini: Gson → Jackson으로 마이그레이션 (#2933)
* Azure `HttpClientProvider` 커스터마이징 기능 추가 (#2822)
* Kotlin 설정 수정 (#2945)
* Jackson 버전을 2.19.0으로 업데이트 (커밋 dc41ebc)

---

## 📑 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트).